### PR TITLE
Update gitignore for temp Word files and local.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ build/
 
 *.iml
 .gradle
-/local.properties
+local.properties
 /build
 /captures
 .externalNativeBuild

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 ehthumbs.db
 Thumbs.db
 
+# Temporary Word files
+~$*.doc*
+
 .idea/
 build/
 


### PR DESCRIPTION
This is minor in the scheme of things, but I tend to use git on the command line a lot and noticed that a couple things weren't being ignored.

1. local.properties
2. temporary files created by Word when a document is open

<img width="502" alt="screen shot 2017-10-18 at 7 18 52 pm" src="https://user-images.githubusercontent.com/4566142/31748494-3f5a96da-b439-11e7-9a89-6c51dce5d549.png">
