### PR TITLE
Various event page fixes and refactorings

### DIFF
--- a/MKESocial/app/src/main/java/Firebase/Event.java
+++ b/MKESocial/app/src/main/java/Firebase/Event.java
@@ -1,6 +1,7 @@
 package Firebase;
 
 
+import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.IgnoreExtraProperties;
 import com.google.firebase.database.Exclude;
 
@@ -33,6 +34,7 @@ public class Event implements Databasable{
     private List<Tag> tags;
     //TODO link to other users https://developer.android.com/training/app-links/deep-linking.html
     private List<String> attendeesUids;
+    private String eid;
 
 
     public Event() {
@@ -281,6 +283,18 @@ public class Event implements Databasable{
 
     public void setAttendeesUids(List<String> attendeesUids) {
         this.attendeesUids = attendeesUids;
+    }
+
+    public String getEventId() { return eid; }
+
+    @Exclude
+    private void setEventId(String id) { eid = id; }
+
+    public static Event fromSnapshot(DataSnapshot snapshot)
+    {
+        Event event = snapshot.getValue(Event.class);
+        event.setEventId(snapshot.getKey());
+        return event;
     }
 
 }

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/BaseActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/BaseActivity.java
@@ -5,6 +5,7 @@ package team2.mkesocial.Activities;
  */
 
 import android.app.ProgressDialog;
+import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 
 //TODO
@@ -42,6 +43,14 @@ public class BaseActivity extends AppCompatActivity {
        return FirebaseAuth.getInstance().getCurrentUser().getUid();
     }
 
+
+    protected void inspectEvent(String eid) {
+        if (eid != null) {
+            Intent goToEventPage = new Intent(this, EventActivity.class);
+            goToEventPage.putExtra("EVENT_ID", eid);
+            startActivity(goToEventPage);
+        }
+    }
 
 
 }

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/EventActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/EventActivity.java
@@ -116,7 +116,7 @@ public class EventActivity extends Activity implements ValueEventListener {
                         String[] locationData = value.split(";");
                         try {
                             addresses = geocoder.getFromLocation(Double.parseDouble(locationData[1]), Double.parseDouble(locationData[2]), 1); // Here 1 represent max location result to returned, by documents it recommended 1 to 5
-                        }catch(IOException e){
+                        }catch(Exception e){
                             Log.d("failed","failed");
                         }
                         if(addresses != null) {

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/EventActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/EventActivity.java
@@ -15,12 +15,8 @@ import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.Query;
 import com.google.firebase.database.ValueEventListener;
 
-import java.io.IOException;
-import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -33,7 +29,7 @@ public class EventActivity extends Activity implements ValueEventListener {
 
     private FirebaseDatabase _database;
     private Query _dataQuery;
-    private String _eventTitle;
+    private String _eventId;
     private TextView title, description, date, startTime, endTime, location, hostUid, suggestedAge, rating, cost;
     private String[] _keys = { "title=", "description=", "date=", "startTime=", "endTime=", "location=", "hostUid=", "suggestedAge=", "rating=", "cost="};
 
@@ -54,28 +50,21 @@ public class EventActivity extends Activity implements ValueEventListener {
 
         _database = FirebaseDatabase.getInstance();
 
-        _eventTitle = getIntent().getStringExtra("EVENT_TITLE");
+        _eventId = getIntent().getStringExtra("EVENT_ID");
 
-        _dataQuery = _database.getReference(Event.DB_EVENTS_NODE_NAME).orderByChild("title").equalTo(_eventTitle);
-        _dataQuery.addChildEventListener(new ChildEventListener() {
-                                             @Override
-                                             public void onChildAdded(DataSnapshot dataSnapshot, String s) {
-                                                 populateEventData(dataSnapshot.toString());
-                                             }
+        _dataQuery = _database.getReference(Event.DB_EVENTS_NODE_NAME).child(_eventId).orderByKey();
+        _dataQuery.addListenerForSingleValueEvent(new ValueEventListener() {
+            @Override
+            public void onDataChange(DataSnapshot dataSnapshot) {
+                populateEventData(dataSnapshot.toString());
+            }
 
-                                             @Override
-                                             public void onChildChanged(DataSnapshot dataSnapshot, String s) {}
+            @Override
+            public void onCancelled(DatabaseError databaseError) {
 
-                                             @Override
-                                             public void onChildRemoved(DataSnapshot dataSnapshot) {}
-
-                                             @Override
-                                             public void onChildMoved(DataSnapshot dataSnapshot, String s) {}
-
-                                             @Override
-                                             public void onCancelled(DatabaseError databaseError) {}
-                                         });
-                Log.d("QUERY RESULTS", _dataQuery.toString());
+            }
+        });
+        Log.d("QUERY RESULTS", _dataQuery.toString());
     }
 
     private void populateEventData(String data){

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/EventActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/EventActivity.java
@@ -56,7 +56,7 @@ public class EventActivity extends Activity implements ValueEventListener {
         _dataQuery.addListenerForSingleValueEvent(new ValueEventListener() {
             @Override
             public void onDataChange(DataSnapshot dataSnapshot) {
-                populateEventData(dataSnapshot.toString());
+                populateEventData(dataSnapshot);
             }
 
             @Override
@@ -67,70 +67,29 @@ public class EventActivity extends Activity implements ValueEventListener {
         Log.d("QUERY RESULTS", _dataQuery.toString());
     }
 
-    private void populateEventData(String data){
-        for (String key : _keys) {
-            SimpleDateFormat timeFormatter = new SimpleDateFormat("hh:MM:SS");
-            SimpleDateFormat dateFormatter = new SimpleDateFormat("MM/dd/yyyy");
-            String value = null;
-            Pattern p = Pattern.compile("(?<="+key+").*?(?=, )");
-            Matcher matcher = p.matcher(data.toString());
-            if (matcher.find()) {
-                try{
-                    value = matcher.group(0);
-                }catch(Exception e){
+    private void populateEventData(DataSnapshot data){
+        Event event = Event.fromSnapshot(data);
+        SimpleDateFormat timeFormatter = new SimpleDateFormat("hh:MM:SS");
+        SimpleDateFormat dateFormatter = new SimpleDateFormat("MM/dd/yyyy");
 
-                }
-                if(value != null && !value.equals("-1")){
-                    if(key.contains("title")){
-                        title.setText(value);
-                    }else if(key.contains("description")){
-                        description.setText(value);
-                    }else if(key.contains("date")){
-                        Date eventDate = new Date();
-                        eventDate.setTime(Long.parseLong(value));
-                        date.setText(dateFormatter.format(eventDate));
-                    }else if(key.contains("startTime")){
-                        Date date = new Date();
-                        date.setTime(Long.parseLong(value));
-                        startTime.setText(timeFormatter.format(date));
-                    }else if(key.contains("endTime")){
-                        Date date = new Date();
-                        date.setTime(Long.parseLong(value));
-                        endTime.setText((timeFormatter.format(date)));
-                    }else if(key.contains("location")){
-                        Geocoder geocoder;
-                        List<Address> addresses = null;
-                        geocoder = new Geocoder(this, Locale.getDefault());
+        title.setText(event.getTitle());
+        description.setText(event.getDescription());
+        date.setText(dateFormatter.format(event.getDate().getTime()));
+        startTime.setText(timeFormatter.format(event.getStartTime().getTime()));
+        endTime.setText(timeFormatter.format(event.getEndTime().getTime()));
+        location.setText(event.getLocation().getAddressLine(0));
 
-                        String[] locationData = value.split(";");
-                        try {
-                            addresses = geocoder.getFromLocation(Double.parseDouble(locationData[1]), Double.parseDouble(locationData[2]), 1); // Here 1 represent max location result to returned, by documents it recommended 1 to 5
-                        }catch(Exception e){
-                            Log.d("failed","failed");
-                        }
-                        if(addresses != null) {
-                            Log.d("address",addresses.toString());
-                         //   String address = addresses.get(0).getAddressLine(0); // If any additional address line present than only, check with max available address lines by getMaxAddressLineIndex()
-                           // String city = addresses.get(0).getLocality();
-                           // String state = addresses.get(0).getAdminArea();
-                           // String country = addresses.get(0).getCountryName();
-                            //String postalCode = addresses.get(0).getPostalCode();
-                            //String knownName = addresses.get(0).getFeatureName();
-                        }
-                        //TODO have real locations stored
-                        location.setText("Address: "+locationData[0]);
-                    }else if(key.contains("hostUid")){
-                        //hostUid.setText(value);
-                    }else if(key.contains("suggestedAge")){
-                        suggestedAge.setText(value);
-                    }else if(key.contains("rating")){
-                        rating.setText(value);
-                    }else if(key.contains("cost")){
-                        cost.setText(value);
-                    }
-                }
-            }
-        }
+        int ageData = event.getSuggestedAge();
+        if (ageData != -1)
+            suggestedAge.setText(Integer.toString(ageData));
+
+        int ratingData = event.getRating();
+        if (ratingData != -1)
+            rating.setText(Integer.toString(ratingData));
+
+        double costData = event.getCost();
+        if (costData != -1.0f)
+            cost.setText(String.format("%.2f", costData));
     }
 
     @Override

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/MyEventsActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/MyEventsActivity.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 
 import Firebase.Event;
-import team2.mkesocial.EventAdapter;
+import team2.mkesocial.Adapters.EventAdapter;
 import team2.mkesocial.EventDecorator;
 import team2.mkesocial.R;
 import team2.mkesocial.WeekendDecorator;

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/MyEventsActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/MyEventsActivity.java
@@ -4,6 +4,8 @@ import android.support.annotation.NonNull;
 import android.os.Bundle;
 import android.graphics.Color;
 import android.util.Log;
+import android.view.View;
+import android.widget.AdapterView;
 import android.widget.ListView;
 
 import com.google.firebase.database.DataSnapshot;
@@ -59,6 +61,14 @@ public class MyEventsActivity extends BaseActivity implements OnDateSelectedList
 
         _eventAdapter = new EventAdapter(this, _events);
         _eventList.setAdapter(_eventAdapter);
+
+        _eventList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                Event selectedEvent = (Event)_eventList.getItemAtPosition(position);
+                inspectEvent(selectedEvent.getEventId());
+            }
+        });
     }
 
     @Override
@@ -100,7 +110,7 @@ public class MyEventsActivity extends BaseActivity implements OnDateSelectedList
                     @Override
                     public void onDataChange(DataSnapshot dataSnapshot) {
                         try {
-                            Event event = dataSnapshot.getValue(Event.class);
+                            Event event = Event.fromSnapshot(dataSnapshot);
 
                             if (event != null) {
                                 Log.d(TAG, event.getTitle());

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
@@ -5,7 +5,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.AdapterView;
-import android.widget.Button;
 import android.widget.SearchView;
 import android.widget.ListView;
 import android.widget.ArrayAdapter;
@@ -29,6 +28,7 @@ import Firebase.Event;
 import Firebase.Tag;
 import team2.mkesocial.DateFilterFragment;
 import team2.mkesocial.R;
+import team2.mkesocial.SimpleEventAdapter;
 
 public class SearchActivity extends AppCompatActivity
         implements SearchView.OnQueryTextListener,
@@ -42,8 +42,8 @@ public class SearchActivity extends AppCompatActivity
     private TextView _searchTextField;
     private Spinner _searchFilter;
     private ListView _searchResults;
-    private ArrayList<String> _eventList;
-    private ArrayAdapter<String> _resultsAdapter;
+    private ArrayList<Event> _eventList;
+    private SimpleEventAdapter _resultsAdapter;
     private FirebaseDatabase _database;
     private Query _dataQuery;
     private String _queryString;
@@ -63,7 +63,8 @@ public class SearchActivity extends AppCompatActivity
         _searchResults.setOnItemClickListener(new AdapterView.OnItemClickListener() {
                 public void onItemClick(AdapterView<?> parent, View view,int position, long id)
                 {
-                    _selectedEventTitle = _searchResults.getItemAtPosition(position).toString();
+                    Event selectedEvent = (Event)_searchResults.getItemAtPosition(position);
+                    _selectedEventTitle = selectedEvent.getTitle();
                     inspectEvent();
                 }}
             );
@@ -74,7 +75,7 @@ public class SearchActivity extends AppCompatActivity
         _searchView.setOnQueryTextListener(this);
 
         _eventList = new ArrayList<>();
-        _resultsAdapter = new ArrayAdapter<>(this, R.layout.list_item_searchresult, _eventList);
+        _resultsAdapter = new SimpleEventAdapter(this, _eventList);
         _searchResults.setAdapter(_resultsAdapter);
 
         _database = FirebaseDatabase.getInstance();
@@ -159,7 +160,7 @@ public class SearchActivity extends AppCompatActivity
                 }
 
                 if (shouldAdd) {
-                    _resultsAdapter.add(event.getTitle());
+                    _resultsAdapter.add(event);
                     if (_searchActivityToast != null) {
                         _searchActivityToast.cancel();
                         _searchActivityToast = null;

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
@@ -7,7 +7,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.SearchView;
 import android.widget.ListView;
-import android.widget.ArrayAdapter;
 import android.util.Log;
 import android.widget.Spinner;
 import android.widget.TextView;
@@ -28,7 +27,7 @@ import Firebase.Event;
 import Firebase.Tag;
 import team2.mkesocial.DateFilterFragment;
 import team2.mkesocial.R;
-import team2.mkesocial.SimpleEventAdapter;
+import team2.mkesocial.Adapters.SimpleEventAdapter;
 
 public class SearchActivity extends AppCompatActivity
         implements SearchView.OnQueryTextListener,

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
@@ -49,7 +49,6 @@ public class SearchActivity extends AppCompatActivity
     private Date _filterStartDate;
     private Date _filterEndDate;
     private Toast _searchActivityToast;
-    private String _selectedEventTitle;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -63,8 +62,7 @@ public class SearchActivity extends AppCompatActivity
                 public void onItemClick(AdapterView<?> parent, View view,int position, long id)
                 {
                     Event selectedEvent = (Event)_searchResults.getItemAtPosition(position);
-                    _selectedEventTitle = selectedEvent.getTitle();
-                    inspectEvent();
+                    inspectEvent(selectedEvent.getEventId());
                 }}
             );
 
@@ -90,11 +88,10 @@ public class SearchActivity extends AppCompatActivity
         }
     }
 
-    private void inspectEvent(){
-        if(_selectedEventTitle != null){
+    private void inspectEvent(String eid) {
+        if (eid != null) {
             Intent goToEventPage = new Intent(this, EventActivity.class);
-            goToEventPage.putExtra("EVENT_TITLE",_selectedEventTitle);
-            _selectedEventTitle = null;
+            goToEventPage.putExtra("EVENT_ID", eid);
             startActivity(goToEventPage);
         }
     }

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
@@ -109,8 +109,10 @@ public class SearchActivity extends BaseActivity
     @Override
     public boolean onQueryTextChange(String newText)
     {
-        if (newText.equals(""))
+        if (newText.equals("")) {
             _resultsAdapter.clear();
+            _resultsAdapter.notifyDataSetChanged();
+        }
         return false;
     }
 
@@ -153,6 +155,7 @@ public class SearchActivity extends BaseActivity
                         _searchActivityToast.cancel();
                         _searchActivityToast = null;
                     }
+                    _resultsAdapter.notifyDataSetChanged();
                 }
 
                 if (event != null)

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
@@ -131,7 +131,7 @@ public class SearchActivity extends AppCompatActivity
         for (DataSnapshot snapshot : dataSnapshot.getChildren()) {
             try {
                 boolean shouldAdd = false;
-                Event event = snapshot.getValue(Event.class);
+                Event event = Event.fromSnapshot(snapshot);
 
                 switch (_searchFilter.getSelectedItemPosition())
                 {

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
@@ -50,7 +50,6 @@ public class SearchActivity extends AppCompatActivity
     private Date _filterStartDate;
     private Date _filterEndDate;
     private Toast _searchActivityToast;
-    private Button _openEventButton;
     private String _selectedEventTitle;
 
     @Override
@@ -65,7 +64,7 @@ public class SearchActivity extends AppCompatActivity
                 public void onItemClick(AdapterView<?> parent, View view,int position, long id)
                 {
                     _selectedEventTitle = _searchResults.getItemAtPosition(position).toString();
-                    Log.d("SELECTED", _selectedEventTitle);
+                    inspectEvent();
                 }}
             );
 
@@ -82,15 +81,6 @@ public class SearchActivity extends AppCompatActivity
 
         _searchView.setIconified(false);
         _searchFilter.setOnItemSelectedListener(this);
-
-        _openEventButton = (Button)findViewById(R.id.open_event_button);
-        _openEventButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Log.d("test", "Clicked");
-                inspectEvent();
-            }
-        });
 
         if (savedInstanceState != null) {
             DateFilterFragment dff = (DateFilterFragment)getSupportFragmentManager().findFragmentByTag(TAG);

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/SearchActivity.java
@@ -29,7 +29,7 @@ import team2.mkesocial.DateFilterFragment;
 import team2.mkesocial.R;
 import team2.mkesocial.Adapters.SimpleEventAdapter;
 
-public class SearchActivity extends AppCompatActivity
+public class SearchActivity extends BaseActivity
         implements SearchView.OnQueryTextListener,
         ValueEventListener,
         AdapterView.OnItemSelectedListener,
@@ -85,14 +85,6 @@ public class SearchActivity extends AppCompatActivity
             if (dff != null) {
                 dff.setListener(this);
             }
-        }
-    }
-
-    private void inspectEvent(String eid) {
-        if (eid != null) {
-            Intent goToEventPage = new Intent(this, EventActivity.class);
-            goToEventPage.putExtra("EVENT_ID", eid);
-            startActivity(goToEventPage);
         }
     }
 

--- a/MKESocial/app/src/main/java/team2/mkesocial/Adapters/EventAdapter.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Adapters/EventAdapter.java
@@ -1,4 +1,4 @@
-package team2.mkesocial;
+package team2.mkesocial.Adapters;
 
 import android.content.Context;
 import android.view.LayoutInflater;
@@ -8,6 +8,8 @@ import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import Firebase.Event;
+import team2.mkesocial.R;
+
 import java.util.ArrayList;
 import java.text.SimpleDateFormat;
 

--- a/MKESocial/app/src/main/java/team2/mkesocial/Adapters/SimpleEventAdapter.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Adapters/SimpleEventAdapter.java
@@ -1,4 +1,4 @@
-package team2.mkesocial;
+package team2.mkesocial.Adapters;
 
 import android.content.Context;
 import android.view.LayoutInflater;
@@ -10,6 +10,7 @@ import android.widget.TextView;
 import java.util.ArrayList;
 
 import Firebase.Event;
+import team2.mkesocial.R;
 
 public class SimpleEventAdapter extends BaseAdapter {
     private Context _context;
@@ -47,7 +48,7 @@ public class SimpleEventAdapter extends BaseAdapter {
     public View getView(int position, View convertView, ViewGroup parent) {
         // Get view for event item
         TextView eventItem = (TextView)_inflater.inflate(R.layout.list_item_searchresult, parent, false);
-        
+
         Event e = (Event)getItem(position);
         eventItem.setText(e.getTitle());
 

--- a/MKESocial/app/src/main/java/team2/mkesocial/SimpleEventAdapter.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/SimpleEventAdapter.java
@@ -1,0 +1,56 @@
+package team2.mkesocial;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+
+import Firebase.Event;
+
+public class SimpleEventAdapter extends BaseAdapter {
+    private Context _context;
+    private LayoutInflater _inflater;
+    private ArrayList<Event> _dataSource;
+
+    public SimpleEventAdapter(Context context, ArrayList<Event> items) {
+        _context = context;
+        _dataSource = items;
+        _inflater = (LayoutInflater)context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+    }
+
+    public void add (Event event) {
+        _dataSource.add(event);
+    }
+
+    public void clear() { _dataSource.clear();}
+
+    @Override
+    public int getCount() {
+        return _dataSource.size();
+    }
+
+    @Override
+    public Object getItem(int position) {
+        return _dataSource.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        // Get view for event item
+        TextView eventItem = (TextView)_inflater.inflate(R.layout.list_item_searchresult, parent, false);
+        
+        Event e = (Event)getItem(position);
+        eventItem.setText(e.getTitle());
+
+        return eventItem;
+    }
+}

--- a/MKESocial/app/src/main/res/layout/activity_search.xml
+++ b/MKESocial/app/src/main/res/layout/activity_search.xml
@@ -51,12 +51,4 @@
         android:layout_marginTop="5dp"
         android:padding="10dp" />
 
-    <Button
-        android:id="@+id/open_event_button"
-        style="@android:style/Widget.Button.Inset"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:text="Open Event" />
-
 </android.widget.RelativeLayout>


### PR DESCRIPTION
Summary of major changes:

- Removed open event button on Search page in favor of just being able to click the search result and open the event page from that
- Hooked up event page to My Events and Feed pages
- The event page populates data using the event's key instead of the title. This was a problem before if two events had the same title.
- Added static Event.fromSnapshot method to convert Firebase's DataSnaphot to an Event object. This automatically fills in the event's key for you.
- Moved inspectEvent from SearchActivity to BaseActivity as a protected method. Inherit from BaseActivity, and you can use this to open the event page from any activity by passing in an event key,
- Removed regex parsing from event page in favor of just using the above Event.fromSnapshot method. There was previously a problem with parsing the event location with the regex if there were commas in the address.