### PR TITLE
Fix map marker colors after bad merge.

### DIFF
--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/MapsActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/MapsActivity.java
@@ -126,14 +126,14 @@ public class MapsActivity extends BaseActivity implements OnMapReadyCallback {
                                         for(int i=0; i<aEv.length;++i) {
                                             if (event.getEventId().equals(aEv[i])){  //
                                                 eventM = mMap.addMarker(new MarkerOptions().position(new LatLng(MethodOrphanage.getLat(event.getLocation()),
-                                                        MethodOrphanage.getLng(event.getLocation()))).title(event.getTitle()).icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_ORANGE)));
+                                                        MethodOrphanage.getLng(event.getLocation()))).title(event.getTitle()).icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN)));
                                                 eventM.setTag(aID[i]);
                                             }
                                         }
                                         for(int i=0; i<hEv.length;++i) {
                                             if (event.getEventId().equals(hEv[i])){  //
                                                 eventM = mMap.addMarker(new MarkerOptions().position(new LatLng(MethodOrphanage.getLat(event.getLocation()),
-                                                        MethodOrphanage.getLng(event.getLocation()))).title(event.getTitle()).icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_YELLOW)));
+                                                        MethodOrphanage.getLng(event.getLocation()))).title(event.getTitle()).icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_VIOLET)));
                                                 eventM.setTag(hID[i]);
                                             }
                                         }


### PR DESCRIPTION
I noticed after fcec418066a72b40f7c7015b06666a9a6e1cd7d0 was merged to master, the colors of the map markers got changed. I think the merge conflicts weren't resolved quite correctly? I don't think there are any other problems, but @ongda you might want to double check that everything is still good. The color change was just the most obvious issue I noticed.