### PR TITLE
Fix unsetting of attend or maybe buttons if one of them is already set.

### DIFF
--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/EventActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/EventActivity.java
@@ -150,12 +150,16 @@ public class EventActivity extends BaseActivity implements ValueEventListener {
                 //User gets to know events he/she is attending
                 if(user.getAttendEid().isEmpty()|| !user.getAttendEid().contains(_eventId+"`"+title.getText()+"`")){
                     att.setImageResource(R.mipmap.ic_not_attending_pic);
+                } else {
+                    att.setImageResource(R.mipmap.ic_attending_pic);
+                    att.setContentDescription("true");
                 }
-                else{ att.setImageResource(R.mipmap.ic_attending_pic);}
                 if(user.getMaybeEid().isEmpty()|| !user.getMaybeEid().contains(_eventId+"`"+title.getText()+"`")){
                     maybe.setImageResource(R.mipmap.ic_not_maybe_pic);
+                } else {
+                    maybe.setImageResource(R.mipmap.ic_maybe_pic);
+                    maybe.setContentDescription("true");
                 }
-                else{  maybe.setImageResource(R.mipmap.ic_maybe_pic);}
              }
             @Override
             public void onCancelled(DatabaseError databaseError) {}


### PR DESCRIPTION
If you view an event that you have already expressed interest in via the attend or maybe buttons, you have to click/tap twice on the button to unset it. This fixes that problem so that you only need to click once.