### PR TITLE
Fixed setting initial costs on new events and parsing them when editing events

### DIFF
--- a/MKESocial/app/src/main/java/Firebase/Event.java
+++ b/MKESocial/app/src/main/java/Firebase/Event.java
@@ -1,7 +1,6 @@
 package Firebase;
 
 
-import android.content.Context;
 import android.util.Log;
 
 import com.google.android.gms.location.places.Place;
@@ -19,8 +18,6 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import Validation.WordScrubber;
 
 /**
  * Created by cfoxj2 on 10/23/2017.
@@ -83,7 +80,7 @@ public class Event implements Databasable, Cloneable {
         setAttendes(attendees);
         setSuggestedAge(parseInt(suggestedAge));
         setRating(parseInt(rating));
-        setCost(parseInt(cost));
+        setCost(parseDouble(cost));
         setTags(parseTags(tags));
     }
     public Event(String title, String description, String startDate, String endDate, String startTime,
@@ -100,7 +97,7 @@ public class Event implements Databasable, Cloneable {
         setAttendes(attendees);
         setSuggestedAge(parseInt(suggestedAge));
         setRating(parseInt(rating));
-        setCost(parseInt(cost));
+        setCost(parseDouble(cost));
         setTags(tags);
     }
 
@@ -132,6 +129,20 @@ public class Event implements Databasable, Cloneable {
             return Integer.parseInt(number);
         else
             return -1;
+    }
+
+    private static double parseDouble(String amount)
+    {
+        if (amount.isEmpty())
+            return -1.0f;
+
+        double result;
+        try {
+            result = Double.parseDouble(amount);
+        } catch (NumberFormatException e) {
+            result = -1.0f;
+        }
+        return result;
     }
 
     /**

--- a/MKESocial/app/src/main/java/team2/mkesocial/Activities/CreateEventActivity.java
+++ b/MKESocial/app/src/main/java/team2/mkesocial/Activities/CreateEventActivity.java
@@ -413,8 +413,8 @@ public class CreateEventActivity extends BaseActivity {
 
                         String cleanString = s.toString().replaceAll("[$,.]", "");
 
-                        double parsed = Double.parseDouble(cleanString);
-                        String formatted = NumberFormat.getCurrencyInstance().format((parsed/100));
+                        double parsed = Double.parseDouble(cleanString) / 100;
+                        String formatted = NumberFormat.getCurrencyInstance().format((parsed));
 
                         current = formatted;
                         costField.setText(formatted);


### PR DESCRIPTION
When creating an event, the cost shown in the field does not match what gets set in the database. For example, type 3 which shows $0.03 in the field, but 3.00 is the value in the database entry. Or enter $3.00 in the field and the database gets 300.00. 

Secondly, when editing an existing event, only whole numbers work because it tries to parse the string as an integer. 

This should fix both of these issues.